### PR TITLE
Hotfix: Do not release wakeLock when it does not exist

### DIFF
--- a/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
+++ b/apps/website/src/app/pages/visualizer-page/visualizer-page.component.ts
@@ -104,7 +104,7 @@ export class VisualizerPageComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.gradients = []
-    this.wakeLock.release()
+    this.wakeLock?.release()
       .then()
       .catch((error: any) => console.error('Failed to release wake lock', error));
   }


### PR DESCRIPTION
# Added

# Changed

# Fixed
-  Do not release wakeLock when it does not exist, this happens when the browser does not support wakelock
# Improved
